### PR TITLE
Fix normalize_patient endpoint to use new Groq JSON structure

### DIFF
--- a/backend/app/api_models/schemas.py
+++ b/backend/app/api_models/schemas.py
@@ -36,31 +36,36 @@ class NormalizePatientRequest(BaseModel):
     """Request schema for normalizing patient evidence JSON."""
     patient_evidence: Dict[str, Any] = Field(
         ...,
-        description="Raw patient chart JSON data to normalize",
+        description="Raw patient chart JSON data to normalize (Groq format)",
         examples=[{
-            "timestamp": "2026-01-27T16:32:19.123456",
-            "analysis": {
-                "requirements": {
-                    "symptom_duration_months": 4,
-                    "conservative_therapy": {
-                        "physical_therapy": {
-                            "attempted": True,
-                            "duration_weeks": 8,
-                            "outcome": "failed"
-                        },
-                        "nsaids": {
-                            "documented": True,
-                            "outcome": "failed"
-                        }
+            "filename": "mocked_patient_pass.txt",
+            "score": 100,
+            "requirements": {
+                "symptom_duration_months": 4,
+                "conservative_therapy": {
+                    "physical_therapy": {
+                        "attempted": True,
+                        "duration_weeks": 8,
+                        "outcome": "failed"
                     },
-                    "imaging": {
+                    "nsaids": {
                         "documented": True,
-                        "type": "X-ray",
-                        "body_part": "shoulder",
-                        "months_ago": 1
+                        "outcome": "failed"
                     }
+                },
+                "imaging": {
+                    "documented": True,
+                    "type": "X-ray",
+                    "body_part": "knee",
+                    "months_ago": 1
+                },
+                "_metadata": {
+                    "hallucinations_detected": 0,
+                    "hallucinated_notes": [],
+                    "validation_passed": True
                 }
-            }
+            },
+            "missing_items": []
         }]
     )
 

--- a/backend/app/routers/normalization.py
+++ b/backend/app/routers/normalization.py
@@ -29,25 +29,30 @@ async def normalize_patient(request: NormalizePatientRequest):
     """
     Normalize patient chart JSON to canonical format.
 
-    Takes raw patient evidence JSON (from chart extraction) and converts it to a
+    Takes raw patient evidence JSON (from Groq chart extraction) and converts it to a
     flat dictionary with standardized field names suitable for rule evaluation.
 
     **Example Input:**
     ```json
     {
       "patient_evidence": {
-        "timestamp": "2026-01-27T16:32:19.123456",
-        "analysis": {
-          "requirements": {
-            "symptom_duration_months": 4,
-            "conservative_therapy": {
-              "physical_therapy": {
-                "attempted": true,
-                "duration_weeks": 8
-              }
+        "filename": "mocked_patient_pass.txt",
+        "score": 100,
+        "requirements": {
+          "symptom_duration_months": 4,
+          "conservative_therapy": {
+            "physical_therapy": {
+              "attempted": true,
+              "duration_weeks": 8,
+              "outcome": "failed"
             }
+          },
+          "_metadata": {
+            "hallucinations_detected": 0,
+            "validation_passed": true
           }
-        }
+        },
+        "missing_items": []
       }
     }
     ```
@@ -59,11 +64,15 @@ async def normalize_patient(request: NormalizePatientRequest):
         "symptom_duration_months": 4,
         "symptom_duration_weeks": 16,
         "pt_attempted": true,
-        "pt_duration_weeks": 8
+        "pt_duration_weeks": 8,
+        "validation_passed": true,
+        "hallucinations_detected": 0
       },
       "metadata": {
-        "fields_extracted": 4,
-        "source": "patient_chart"
+        "fields_extracted": 6,
+        "source": "patient_chart",
+        "validation_passed": true,
+        "hallucinations_detected": 0
       }
     }
     ```
@@ -220,14 +229,19 @@ async def normalize_both(request: NormalizeBothRequest):
     ```json
     {
       "patient_evidence": {
-        "analysis": {
-          "requirements": {
-            "symptom_duration_months": 4,
-            "conservative_therapy": {
-              "physical_therapy": {"attempted": true}
-            }
+        "filename": "patient_chart.txt",
+        "score": 100,
+        "requirements": {
+          "symptom_duration_months": 4,
+          "conservative_therapy": {
+            "physical_therapy": {"attempted": true, "duration_weeks": 8}
+          },
+          "_metadata": {
+            "hallucinations_detected": 0,
+            "validation_passed": true
           }
-        }
+        },
+        "missing_items": []
       },
       "policy_criteria": {
         "rules": {


### PR DESCRIPTION
## Summary
- Updated NormalizePatientRequest schema example to match patient_chart_groq.json format
- Updated API endpoint documentation with correct input/output examples
- Removed nested 'analysis' wrapper from examples (old deprecated format)

The normalize_patient_evidence function already handles the new format correctly. The 422 error was caused by outdated schema examples that didn't match the actual Groq output structure.

Fixes #10

Generated with [Claude Code](https://claude.ai/code)