### PR TITLE
Fix AttributeError in normalize_patient_evidence for null outcomes

### DIFF
--- a/backend/app/normalization/normalized_custom.py
+++ b/backend/app/normalization/normalized_custom.py
@@ -63,7 +63,8 @@ def normalize_patient_evidence(evidence: dict) -> dict:
     normalized["nsaid_outcome"] = nsaids.get("outcome")
 
     # Check for failed/unsuccessful outcome (multiple possible values)
-    outcome = nsaids.get("outcome", "").lower()
+    outcome = nsaids.get("outcome") or ""
+    outcome = outcome.lower() if isinstance(outcome, str) else ""
     normalized["nsaid_failed"] = outcome in ["failed", "no relief", "unsuccessful", "ineffective"]
 
     # Injections
@@ -71,7 +72,8 @@ def normalize_patient_evidence(evidence: dict) -> dict:
     normalized["injection_documented"] = injections.get("documented", False)
     normalized["injection_outcome"] = injections.get("outcome")
 
-    outcome = injections.get("outcome", "").lower()
+    outcome = injections.get("outcome") or ""
+    outcome = outcome.lower() if isinstance(outcome, str) else ""
     normalized["injection_failed"] = outcome in ["failed", "no relief", "unsuccessful", "ineffective"]
 
     # Imaging - normalize type field


### PR DESCRIPTION
Fixes #12

## Changes
- Fixed AttributeError when outcome fields are null in patient evidence
- Added proper None handling for nsaids.outcome and injections.outcome fields
- Prevents 500 error on /api/normalize/patient endpoint

## Technical Details
The normalize_patient_evidence function was calling .lower() on outcome fields that could be null, causing AttributeError. Now uses `or ""` operator and isinstance check to safely handle None values.

Generated with [Claude Code](https://claude.ai/code)