### PR TITLE
Fix vectorstore index resolution for combined CPT code indexes

### DIFF
--- a/backend/app/routers/orchestration.py
+++ b/backend/app/routers/orchestration.py
@@ -31,10 +31,15 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 # Map (payer, cpt) to FAISS index names
+# NOTE: Using single combined index per payer for related CPT codes
+# This allows the RAG pipeline to retrieve relevant rules across all CPT codes
+# and use metadata filtering to prioritize the specific CPT code
 INDEX_MAP = {
+    # Utah Medicaid - all knee MRI CPT codes use the same combined index
     ("utah_medicaid", "73721"): "utah_medicaid_73721",
-    ("utah_medicaid", "73722"): "utah_medicaid_73722",
-    ("utah_medicaid", "73723"): "utah_medicaid_73723",
+    ("utah_medicaid", "73722"): "utah_medicaid_73721",
+    ("utah_medicaid", "73723"): "utah_medicaid_73721",
+    # Aetna - separate indexes per CPT (if created separately)
     ("aetna", "73721"): "aetna_73721",
     ("aetna", "73722"): "aetna_73722",
     ("aetna", "73723"): "aetna_73723",


### PR DESCRIPTION
Fixes #24

### Changes
- Updated orchestration.py INDEX_MAP to use single combined index for all Utah Medicaid knee MRI CPT codes (73721, 73722, 73723)
- All three CPT codes now correctly resolve to 'utah_medicaid_73721' index
- Added documentation explaining the combined index strategy and benefits
- Added docstring to build_index() explaining index naming conventions

### Why Combined Index?
1. Efficient retrieval across related CPT codes
2. Shared policy context for similar procedures
3. Simpler maintenance
4. RAG retrieval already supports CPT code metadata filtering

Generated with [Claude Code](https://claude.ai/code)