### PR TITLE
Fix recent_clinical_notes rule to check note recency

### DIFF
--- a/backend/app/services/evidence.py
+++ b/backend/app/services/evidence.py
@@ -159,6 +159,7 @@ EXTRACTION SCHEMA:
   "symptom_duration_months": null,
   "affected_body_part": null,
   "laterality": null,
+  "clinical_notes_date": null,
   "conservative_therapy": {{
     "physical_therapy": {{
       "attempted": false,
@@ -213,6 +214,7 @@ FIELD INSTRUCTIONS:
 - symptom_duration_months: Extract only if explicitly stated (e.g., "3 months of pain" = 3)
 - affected_body_part: knee, shoulder, lumbar spine, cervical spine, brain, etc.
 - laterality: "right", "left", "bilateral", or null
+- clinical_notes_date: Extract the visit date or date of clinical note in YYYY-MM-DD format (e.g., "Date of Visit: January 15, 2025" = "2025-01-15")
 - attempted: true ONLY if chart says therapy was done/tried/completed
 - outcome: Use "failed", "partial", or "successful" ONLY if chart uses these terms or clear equivalents ("no relief"="failed", "minimal improvement"="partial", "improved"="partial", "resolved"="successful")
 - imaging.type: MRI, CT, X-ray, etc.


### PR DESCRIPTION
Fixes #36

The `recent_clinical_notes` rule was incorrectly using `validation_passed` as its condition instead of checking note recency.

### Changes
- Added `clinical_notes_date` field to LLM extraction schema
- Calculate `clinical_notes_days_ago` in `normalize_patient_evidence()`
- Updated `recent_clinical_notes` rule to check `clinical_notes_days_ago <= 30`
- Rule now fails when note date is null or older than 30 days (fail-safe)

Generated with [Claude Code](https://claude.ai/code)