### PR TITLE
Fix patient_name extraction by adding it to LLM schema

### DIFF
--- a/backend/app/routers/orchestration.py
+++ b/backend/app/routers/orchestration.py
@@ -164,11 +164,15 @@ def extract_patient_name(patient_json: dict) -> str:
 
     Tries multiple paths with fallback to "Unknown Patient".
     """
-    # Try direct name field
+    # Try the patient_name field (added to extraction schema)
+    if "patient_name" in patient_json and patient_json["patient_name"]:
+        return patient_json["patient_name"]
+
+    # Try legacy direct name field (for backwards compatibility)
     if "name" in patient_json:
         return patient_json["name"]
 
-    # Try nested in requirements
+    # Try nested in requirements (for backwards compatibility)
     if "requirements" in patient_json:
         reqs = patient_json["requirements"]
         if isinstance(reqs, dict) and "name" in reqs:

--- a/backend/app/services/evidence.py
+++ b/backend/app/services/evidence.py
@@ -156,6 +156,7 @@ CRITICAL RULES:
 
 EXTRACTION SCHEMA:
 {{
+  "patient_name": null,
   "symptom_duration_months": null,
   "affected_body_part": null,
   "laterality": null,
@@ -210,6 +211,7 @@ EXTRACTION SCHEMA:
 }}
 
 FIELD INSTRUCTIONS:
+- patient_name: Extract the full patient name if present in the chart (e.g., "Patient Name: John Doe"). If not present, use null.
 - symptom_duration_months: Extract only if explicitly stated (e.g., "3 months of pain" = 3)
 - affected_body_part: knee, shoulder, lumbar spine, cervical spine, brain, etc.
 - laterality: "right", "left", "bilateral", or null


### PR DESCRIPTION
Fixes #39

## Summary
Fixed the issue where `extract_patient_name()` always returned "Unknown Patient" by adding patient_name to the LLM extraction schema.

## Changes
- Added `patient_name` field to extraction schema in evidence.py
- Updated `extract_patient_name()` to read from `patient_json["patient_name"]`
- Maintained backwards compatibility with legacy name paths

## Testing
Test with patient charts that include patient names to verify extraction works correctly.

Generated with [Claude Code](https://claude.ai/code)