### PR TITLE
Add explicit warnings for unmapped policy criteria

### DIFF
--- a/backend/app/normalization/normalized_custom.py
+++ b/backend/app/normalization/normalized_custom.py
@@ -209,6 +209,43 @@ def normalize_policy_criteria(criteria: dict) -> list:
     Output: List of rules in standardized condition format
 
     IMPROVED: Detects format and handles Groq output, direct policy object, and pre-normalized data.
+
+    IMPORTANT: This function only generates rules for fields that exist in the normalized patient
+    schema. Any policy criteria that reference unmapped fields will be skipped with a warning.
+
+    FIELD MAPPING STATUS:
+    =====================
+    Currently mapped criteria (WILL be evaluated):
+    - X-ray/imaging requirements → imaging_documented, imaging_type, imaging_months_ago
+    - Physical therapy → pt_attempted, pt_duration_weeks, pt_sessions
+    - Medication trials → nsaid_documented, nsaid_outcome, nsaid_failed
+    - Injections → injection_documented, injection_outcome, injection_failed
+    - Clinical notes recency → validation_passed (proxy check)
+    - Evidence quality → validation_passed, hallucinations_detected
+
+    Known unmapped criteria (WILL be skipped with warning):
+    - Renal function (creatinine/eGFR) - OUT OF SCOPE for MVP
+      Reason: Only relevant for MRI with contrast (CPT 73722/73723). Current focus is
+      non-contrast knee MRI (73721). Add renal_function fields when expanding to contrast imaging.
+
+    - Conservative treatment completion (holistic check) - PARTIALLY MAPPED
+      Reason: Individual components (PT, NSAIDs) are checked separately. A holistic "completion"
+      rule would require business logic to determine if "at least two of" treatments were completed.
+      This may require a composite rule or separate completion_status field in patient schema.
+
+    - Contraindications - OUT OF SCOPE for MVP
+      Reason: Contraindication screening requires clinical decision logic beyond PA readiness.
+      This is a safety check that should be performed by the ordering clinician, not automated.
+
+    - Allergy documentation (for contrast imaging) - OUT OF SCOPE for MVP
+      Reason: Same as renal function - only relevant for contrast MRI. Add when expanding scope.
+
+    To add a new criterion:
+    1. Add corresponding field(s) to normalize_patient_evidence()
+    2. Update evidence.py extraction logic to capture the data from clinical notes
+    3. Add rule generation logic in this function
+    4. Add field name to processed_criteria set
+    5. Update validate_normalized_patient() if it's a required field
     """
     import re
     import logging
@@ -264,6 +301,10 @@ def normalize_policy_criteria(criteria: dict) -> list:
     )
     all_text_lower = all_text.lower()
 
+    # Track which criteria are being processed vs. skipped
+    processed_criteria = set()
+    skipped_criteria = []
+
     # =========================================================================
     # RULE 1: X-ray/Imaging Requirement
     # =========================================================================
@@ -271,6 +312,7 @@ def normalize_policy_criteria(criteria: dict) -> list:
     for prereq in prerequisites:
         prereq_lower = prereq.lower()
         if "x-ray" in prereq_lower or "xray" in prereq_lower or "imaging" in prereq_lower:
+            processed_criteria.add("imaging_requirement")
             # Extract timeframe with multiple patterns
             imaging_months = 2  # default
 
@@ -339,6 +381,7 @@ def normalize_policy_criteria(criteria: dict) -> list:
                 pt_weeks_required = 6
 
     if pt_mentioned:
+        processed_criteria.add("physical_therapy_requirement")
         conditions = [
             {
                 "field": "pt_attempted",
@@ -374,6 +417,7 @@ def normalize_policy_criteria(criteria: dict) -> list:
             break
 
     if medication_mentioned:
+        processed_criteria.add("medication_trial_requirement")
         rules_list.append({
             "id": "medication_trial_requirement",
             "description": "Medication trial must be documented",
@@ -394,6 +438,7 @@ def normalize_policy_criteria(criteria: dict) -> list:
     for doc_req in doc_requirements:
         doc_lower = doc_req.lower()
         if "30 days" in doc_lower or "within 30 days" in doc_lower:
+            processed_criteria.add("recent_clinical_notes")
             rules_list.append({
                 "id": "recent_clinical_notes",
                 "description": "Clinical notes must be within 30 days",
@@ -407,6 +452,64 @@ def normalize_policy_criteria(criteria: dict) -> list:
                 ]
             })
             break
+
+    # =========================================================================
+    # DETECT AND WARN ABOUT UNPROCESSED CRITERIA
+    # =========================================================================
+    # Check for criteria that may have been skipped due to missing field mappings
+
+    # Renal function criteria (for MRI with contrast)
+    if any(keyword in all_text_lower for keyword in ["renal", "creatinine", "egfr", "kidney"]):
+        if "renal_function" not in processed_criteria:
+            skipped_criteria.append({
+                "criterion": "renal_function",
+                "reason": "No mapping exists in normalized patient schema",
+                "sample_text": next((text for text in prerequisites + doc_requirements if any(k in text.lower() for k in ["renal", "creatinine", "egfr"])), "Found in context")
+            })
+            logger.warning(
+                "SKIPPED CRITERION: Renal function requirements detected in policy but no field mapping exists. "
+                "This criterion will NOT be evaluated in PA readiness check."
+            )
+
+    # Conservative treatment completion (holistic check, not just individual components)
+    if any(phrase in all_text_lower for phrase in ["conservative treatment completed", "completion of conservative", "conservative therapy completed"]):
+        if "conservative_treatment_completion" not in processed_criteria:
+            skipped_criteria.append({
+                "criterion": "conservative_treatment_completion",
+                "reason": "No holistic completion check - only individual PT/NSAID checks exist",
+                "sample_text": next((text for text in prerequisites + doc_requirements if "complet" in text.lower() and "conservative" in text.lower()), "Found in context")
+            })
+            logger.warning(
+                "SKIPPED CRITERION: Conservative treatment completion requirement detected but only individual "
+                "component checks (PT, NSAIDs) are implemented. A holistic 'completion' validation may be needed."
+            )
+
+    # Generic check for other potentially missed criteria in documentation requirements
+    for doc_req in doc_requirements:
+        doc_lower = doc_req.lower()
+        # Check for common but unprocessed requirements
+        if "contraindication" in doc_lower and "contraindication" not in processed_criteria:
+            skipped_criteria.append({
+                "criterion": "contraindication_check",
+                "reason": "No field mapping for contraindications",
+                "sample_text": doc_req[:100]
+            })
+            logger.warning(f"SKIPPED CRITERION: Contraindication requirement detected but not mapped: {doc_req[:80]}...")
+
+        if "allergy" in doc_lower and "allergy" not in processed_criteria:
+            skipped_criteria.append({
+                "criterion": "allergy_documentation",
+                "reason": "No field mapping for allergy documentation",
+                "sample_text": doc_req[:100]
+            })
+            logger.warning(f"SKIPPED CRITERION: Allergy requirement detected but not mapped: {doc_req[:80]}...")
+
+    # Log summary of skipped criteria
+    if skipped_criteria:
+        logger.warning(
+            f"Policy normalization SKIPPED {len(skipped_criteria)} criteria due to missing field mappings: "
+            f"{[c['criterion'] for c in skipped_criteria]}"
+        )
 
     # =========================================================================
     # RULE 5: Evidence Quality Check (ALWAYS INCLUDE)
@@ -442,6 +545,9 @@ def normalize_policy_criteria(criteria: dict) -> list:
     })
 
     logger.info(f"Returning {len(rules_list)} total rules (including evidence_quality)")
+    logger.info(f"Processed criteria: {sorted(processed_criteria)}")
+    if skipped_criteria:
+        logger.info(f"Skipped {len(skipped_criteria)} criteria - see warnings above for details")
     return rules_list
 
 

--- a/test_normalization_warnings.py
+++ b/test_normalization_warnings.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Test script to verify that normalize_policy_criteria() logs warnings
+for unmapped policy criteria.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+# Add backend to path
+backend_path = Path(__file__).parent / "backend"
+sys.path.insert(0, str(backend_path))
+
+from app.normalization.normalized_custom import normalize_policy_criteria
+
+# Configure logging to see warnings
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(levelname)s - %(name)s - %(message)s'
+)
+
+def test_renal_function_warning():
+    """Test that renal function criteria trigger warnings"""
+    print("\n" + "="*80)
+    print("TEST 1: Policy with renal function requirement")
+    print("="*80)
+
+    policy_with_renal = {
+        "rules": {
+            "payer": "Utah Medicaid",
+            "cpt_code": "73722",
+            "coverage_criteria": {
+                "prerequisites": [
+                    "X-rays within 60 days",
+                    "Physical therapy for at least 6 weeks"
+                ],
+                "documentation_requirements": [
+                    "Creatinine/eGFR within 6 months if member has renal disease",
+                    "Conservative treatment records"
+                ]
+            }
+        },
+        "context": []
+    }
+
+    rules = normalize_policy_criteria(policy_with_renal)
+    print(f"\nGenerated {len(rules)} rules")
+    print("Expected: WARNING about skipped renal function criterion")
+
+def test_conservative_completion_warning():
+    """Test that conservative treatment completion triggers warnings"""
+    print("\n" + "="*80)
+    print("TEST 2: Policy with conservative treatment completion requirement")
+    print("="*80)
+
+    policy_with_completion = {
+        "rules": {
+            "payer": "Utah Medicaid",
+            "cpt_code": "73721",
+            "coverage_criteria": {
+                "prerequisites": [
+                    "Conservative treatment completed",
+                    "X-rays within 60 days"
+                ],
+                "documentation_requirements": [
+                    "Physical therapy notes",
+                    "Medication trial documentation"
+                ]
+            }
+        },
+        "context": []
+    }
+
+    rules = normalize_policy_criteria(policy_with_completion)
+    print(f"\nGenerated {len(rules)} rules")
+    print("Expected: WARNING about conservative treatment completion")
+
+def test_multiple_unmapped_criteria():
+    """Test policy with multiple unmapped criteria"""
+    print("\n" + "="*80)
+    print("TEST 3: Policy with multiple unmapped criteria")
+    print("="*80)
+
+    policy_complex = {
+        "rules": {
+            "payer": "Utah Medicaid",
+            "cpt_code": "73722",
+            "coverage_criteria": {
+                "prerequisites": [
+                    "Conservative treatment completed",
+                    "X-rays within 60 days"
+                ],
+                "documentation_requirements": [
+                    "Renal function documentation (creatinine/eGFR)",
+                    "Contrast allergy documentation if applicable",
+                    "Documentation of any contraindications"
+                ]
+            }
+        },
+        "context": []
+    }
+
+    rules = normalize_policy_criteria(policy_complex)
+    print(f"\nGenerated {len(rules)} rules")
+    print("Expected: WARNINGS about renal function, conservative completion, allergy, contraindications")
+
+def test_normal_policy_no_warnings():
+    """Test that a normal Aetna policy doesn't trigger false warnings"""
+    print("\n" + "="*80)
+    print("TEST 4: Normal Aetna policy (should not trigger warnings)")
+    print("="*80)
+
+    normal_policy = {
+        "rules": {
+            "payer": "Aetna",
+            "cpt_code": "73721",
+            "coverage_criteria": {
+                "prerequisites": [
+                    "At least 6 weeks of conservative therapy including physical therapy and NSAIDs",
+                    "X-rays within 60 days"
+                ],
+                "documentation_requirements": [
+                    "Recent clinical notes (within 30 days)",
+                    "Physical therapy notes",
+                    "Medication trial documentation"
+                ]
+            }
+        },
+        "context": []
+    }
+
+    rules = normalize_policy_criteria(normal_policy)
+    print(f"\nGenerated {len(rules)} rules")
+    print("Expected: No warnings about skipped criteria")
+
+if __name__ == "__main__":
+    print("\nTesting normalize_policy_criteria() warning system")
+    print("This verifies that unmapped criteria are logged, not silently dropped\n")
+
+    test_renal_function_warning()
+    test_conservative_completion_warning()
+    test_multiple_unmapped_criteria()
+    test_normal_policy_no_warnings()
+
+    print("\n" + "="*80)
+    print("TESTS COMPLETE")
+    print("="*80)
+    print("\nReview the warnings above to verify that unmapped criteria are being detected.")


### PR DESCRIPTION
Fixes #40

Adds explicit warning logs in `normalize_policy_criteria()` whenever a policy criterion is skipped due to missing field mapping. All unmapped criteria are now documented as either out-of-scope or partially mapped with clear reasoning.

## Changes
- Added tracking of processed vs. skipped criteria with detailed logging
- Warns for: renal function, conservative treatment completion, contraindications, allergy documentation
- Documented all field mapping decisions in function docstring
- Added test script to verify warning system

Generated with [Claude Code](https://claude.ai/code)