### PR TITLE
Fix normalized_custom.py issues from merge conflicts

### DIFF
--- a/backend/app/normalization/normalized_custom.py
+++ b/backend/app/normalization/normalized_custom.py
@@ -180,6 +180,10 @@ def normalize_patient_evidence(evidence: dict) -> dict:
     # Evidence notes
     normalized["evidence_notes"] = data_source.get("evidence_notes", [])
 
+    # Clinical notes age - extract from metadata or set default
+    # This represents how recent the clinical documentation is
+    normalized["clinical_notes_days_ago"] = metadata.get("clinical_notes_days_ago", 0)
+
     # Top level data from Groq output
     normalized["score"] = evidence.get("score")
     normalized["missing_items"] = evidence.get("missing_items", [])
@@ -542,7 +546,6 @@ def normalize_policy_criteria(criteria: dict) -> list:
         )
 
     # =========================================================================
-    # RULE 5: Evidence Quality Check (ALWAYS INCLUDE)
     # RULE 5: Clinical Indication Requirement (CRITICAL GATING CRITERION)
     # =========================================================================
     # This checks if the patient has a valid clinical indication from the payer's list
@@ -587,10 +590,6 @@ def normalize_policy_criteria(criteria: dict) -> list:
             })
             logger.info(f"Added clinical_indication_requirement rule with {len(normalized_indications)} allowed indications")
 
-    # =========================================================================
-    # RULE 6: Evidence Quality Check (ALWAYS INCLUDE)
-    # =========================================================================
-
     # Log warning if no clinical rules were generated
     if len(rules_list) == 0:
         logger.warning(
@@ -602,6 +601,9 @@ def normalize_policy_criteria(criteria: dict) -> list:
     else:
         logger.info(f"Generated {len(rules_list)} clinical rules before evidence_quality rule")
 
+    # =========================================================================
+    # RULE 6: Evidence Quality Check (ALWAYS INCLUDE)
+    # =========================================================================
     rules_list.append({
         "id": "evidence_quality",
         "description": "Evidence must be validated with no hallucinations",


### PR DESCRIPTION
Fixes three issues in `normalized_custom.py` that were likely caused by merge conflicts:

1. **Added missing `clinical_notes_days_ago` field** in `normalize_patient_evidence()`
   - This field was required in validation and used in policy rules, but was never set
   - Now extracted from metadata with default value of 0

2. **Removed duplicate RULE 5 comment**
   - Conflicting comments were cleaned up

3. **Added proper RULE 6 section header**
   - Evidence quality check now has consistent formatting

Closes #46

---
Generated with [Claude Code](https://claude.ai/code)