### PR TITLE
refactor: schema-driven patient extraction in pa.py

### DIFF
--- a/backend/app/api_models/schemas.py
+++ b/backend/app/api_models/schemas.py
@@ -160,6 +160,22 @@ class NormalizeBothResponse(BaseModel):
     )
 
 
+# ===== Schema-Driven Extraction Schema =====
+
+class SchemaExtractionResponse(BaseModel):
+    """Response schema for the schema-driven patient chart extraction endpoint."""
+    filename: str = Field(..., description="Name of the uploaded chart file")
+    payer: str = Field(..., description="Payer identifier used to load compiled rules")
+    cpt_code: str = Field(..., description="CPT code used to load compiled rules")
+    patient_data: Dict[str, Any] = Field(
+        ...,
+        description=(
+            "Extracted patient field values keyed by schema field name. "
+            "Fields match exactly what the compiled rule set requires."
+        ),
+    )
+
+
 # ===== Orchestration Schemas =====
 
 class CriterionResult(BaseModel):

--- a/backend/app/routers/pa.py
+++ b/backend/app/routers/pa.py
@@ -1,72 +1,116 @@
-from fastapi import APIRouter, UploadFile, File, HTTPException
+"""
+Prior Authorization — schema-driven patient chart extraction endpoint.
+
+POST /api/extract_patient_chart
+
+Follows Phase 2 (Schema-Driven Patient Extraction) from docs/architecture_guide.md:
+  1. Ingest the uploaded chart file → plain text.
+  2. Load the compiled rule set for the requested payer/CPT combination.
+  3. Extract patient fields from the chart using the compiled extraction_schema.
+  4. Return the extracted field values for downstream rule evaluation.
+
+PHI boundary: chart text contains PHI. extract_evidence_schema_driven() enforces
+provider="bedrock" and will raise ValueError for any other provider.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+
+from app.api_models.schemas import SchemaExtractionResponse
+from app.services.evidence import get_extractor
 from app.services.ingestion import extract_text
-from app.services.evidence import extract_evidence
-from app.services.readiness import compute_readiness
-from app.utils.save_json import save_analysis_to_json
-from app.api_models.schemas import InitialPatientExtraction
-# from app.services.justification import build_justification
-# THIS OUTPUTS MY PATIENT CHART JSON
-# TODO make this strictly a patient chart extracter. Since this will be working with HIPPA, I probably will need to rework this.
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Compiled rule sets are stored here by compile_policy.py
+COMPILED_RULES_DIR = (
+    Path(__file__).resolve().parent.parent / "rag_pipeline" / "compiled_rules"
+)
+
+
+def _load_compiled_rules(payer: str, cpt_code: str) -> dict | None:
+    """Load a compiled rule set from disk. Returns None if not found."""
+    path = COMPILED_RULES_DIR / f"{payer}_{cpt_code}.json"
+    if not path.exists():
+        return None
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
 
 
 # ---------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------
-@router.post("/extract_patient_chart", response_model=InitialPatientExtraction)
-async def analyze_pa(file: UploadFile = File(...)):
+
+@router.post("/extract_patient_chart", response_model=SchemaExtractionResponse)
+async def extract_patient_chart(
+    file: UploadFile = File(...),
+    payer: str = Form(...),
+    cpt_code: str = Form(...),
+):
     """
-    Analyze a prior authorization document.
-    Accepts PDF, DOCX, or TXT files.
-    
+    Extract structured patient evidence from a chart using schema-driven extraction.
+
+    Loads the compiled extraction schema for the given payer/CPT combination
+    and uses it to drive PHI extraction via AWS Bedrock (BAA-covered).
+
+    Args:
+        file:     Patient chart PDF or TXT file (contains PHI).
+        payer:    Payer identifier matching a compiled rule set (e.g. "utah_medicaid").
+        cpt_code: CPT code matching a compiled rule set (e.g. "73721").
+
     Returns:
-        - filename: Name of the uploaded file
-        - score: Readiness score for the PA
-        - requirements: Extracted evidence from the document
-        - missing_items: List of missing required items
+        Extracted patient field values keyed by schema field name.
     """
     try:
-        # Read file contents
         contents = await file.read()
-        
-        # Extract text from the uploaded file
         text = extract_text(contents)
-        print('extracted successful...')
-        # print('text: ', text)
 
-        print('long wait begins...')
-        # Process the document
-        evidence = extract_evidence(text, use_groq=True)
-        print('evidence extracted...')
+        # Load compiled rules for this payer/CPT pair
+        compiled = _load_compiled_rules(payer, cpt_code)
+        if compiled is None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"No compiled rules found for payer='{payer}', cpt_code='{cpt_code}'. "
+                    "Run compile_policy() first via POST /api/compile_policy."
+                ),
+            )
 
+        extraction_schema = compiled.get("extraction_schema")
+        if not extraction_schema:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"Compiled rules for {payer}/{cpt_code} contain no extraction_schema. "
+                    "Re-run compile_policy() to regenerate the rule set."
+                ),
+            )
 
-        score, missing = compute_readiness(evidence)
-        print('computed score...')
+        # Schema-driven PHI extraction — Bedrock is enforced inside this method
+        extractor = get_extractor(use_groq=True)
+        patient_data = extractor.extract_evidence_schema_driven(
+            chart_text=text,
+            extraction_schema=extraction_schema,
+            provider="bedrock",
+        )
 
-        # Create response object
-        response = InitialPatientExtraction(
+        return SchemaExtractionResponse(
             filename=file.filename,
-            score=score,
-            requirements=evidence,
-            missing_items=missing,
+            payer=payer,
+            cpt_code=cpt_code,
+            patient_data=patient_data,
         )
-        
-        # Save to JSON file in the root directory
-        # Convert Pydantic model to dict for JSON serialization
-        # response_dict = response.model_dump()
-        # saved_path = save_analysis_to_json(response_dict, output_dir=".")
-        
-        # print(f'Analysis succeeded and saved to {saved_path}!')
-        
-        return response
-    
+
+    except HTTPException:
+        raise
     except Exception as e:
-        raise HTTPException(
-            status_code=500, 
-            detail=f"Error processing file: {str(e)}"
-        )
-    
+        logger.error("Schema-driven extraction failed: %s", e)
+        raise HTTPException(status_code=500, detail="Error processing chart file.")
+
     finally:
-        # Clean up - close the file
         await file.close()


### PR DESCRIPTION
Refactors `POST /api/extract_patient_chart` to use `extract_evidence_schema_driven()` following Phase 2 of the architecture guide.

Closes #70

Generated with [Claude Code](https://claude.ai/code)